### PR TITLE
actuator/hw_component: drop reference to owner

### DIFF
--- a/ratbag_emu/actuator.py
+++ b/ratbag_emu/actuator.py
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-import typing
 
 from abc import ABC, abstractmethod
 from typing import List
-
-if typing.TYPE_CHECKING:
-    from ratbag_emu.device import Device  # pragma: no cover
 
 
 class Actuator(ABC):
@@ -16,10 +12,8 @@ class Actuator(ABC):
 
     Transforms actions based on physical properties
     '''
-    def __init__(self, owner: 'Device'):
+    def __init__(self):
         self.__logger = logging.getLogger('ratbag-emu.actuator')
-
-        self._owner = owner
 
         self._keys: List[str] = []
 

--- a/ratbag_emu/actuators/sensor.py
+++ b/ratbag_emu/actuators/sensor.py
@@ -10,8 +10,8 @@ class SensorActuator(Actuator):
 
     Transform x and y values based on the DPI value.
     '''
-    def __init__(self, owner, dpi):
-        super().__init__(owner)
+    def __init__(self, dpi):
+        super().__init__()
         self._keys = ['x', 'y']
         self.dpi = dpi
 

--- a/ratbag_emu/hardware/led.py
+++ b/ratbag_emu/hardware/led.py
@@ -7,6 +7,6 @@ class LedComponent(HWComponent):
     '''
     Represents a simple led (on/off)
     '''
-    def __init__(self, owner, state=True):
-        super().__init__(owner)
+    def __init__(self, state=True):
+        super().__init__()
         self.state: bool = state

--- a/ratbag_emu/hw_component.py
+++ b/ratbag_emu/hw_component.py
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-import typing
 
 from typing import Any
-
-if typing.TYPE_CHECKING:
-    from ratbag_emu.device import Device  # pragma: no cover
 
 
 class HWComponent(object):
@@ -15,9 +11,7 @@ class HWComponent(object):
 
     This is the "brain" of the device. The custom logic is implemented here.
     '''
-    def __init__(self, owner: 'Device', state: Any = None):
+    def __init__(self, state: Any = None):
         self.__logger = logging.getLogger('ratbag-emu.hw_component')
-
-        self._owner = owner
 
         self.state = state

--- a/tests/test_actuators.py
+++ b/tests/test_actuators.py
@@ -10,7 +10,7 @@ class TestSensorActuator(TestDeviceBase):
     def test_transform(self):
         dpi = 1000
 
-        actuator = SensorActuator(None, dpi)
+        actuator = SensorActuator(dpi)
 
         data = {
             'x': 5,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -70,8 +70,8 @@ class TestDevice(TestDeviceBase):
         '''
         with pytest.raises(AssertionError):
             device.actuators += [
-                SensorActuator(device, dpi=1000),
-                SensorActuator(device, dpi=1000)
+                SensorActuator(dpi=1000),
+                SensorActuator(dpi=1000)
             ]
 
     def test_mouse_report(self, device, events):
@@ -98,7 +98,7 @@ class TestDevice(TestDeviceBase):
         dpi = 1000
 
         device.actuators += [
-            SensorActuator(device, dpi)
+            SensorActuator(dpi)
         ]
 
         action = {
@@ -123,7 +123,7 @@ class TestDevice(TestDeviceBase):
         '''
         device.report_rate = 1000
         device.actuators += [
-            SensorActuator(device, dpi=1000)
+            SensorActuator(dpi=1000)
         ]
 
         action = {

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -7,7 +7,7 @@ from tests.test_device import TestDeviceBase
 
 class TestHardware(TestDeviceBase):
     def test_led(self, device):
-        device.hw['led1'] = LedComponent(device, state=True)
+        device.hw['led1'] = LedComponent(state=True)
         assert device.hw['led1'].state
 
         device.hw['led1'].state = False


### PR DESCRIPTION
There's no reason for Actuator or HWComponent to have a reference to the
owner. They just transform data or provide external properties. They don't
need to interact with Device at all, Device should interact with them.

Signed-off-by: Filipe Laíns <lains@archlinux.org>