### PR TITLE
device: fix closing event nodes when there is an error when sending events

### DIFF
--- a/ratbag_emu/device.py
+++ b/ratbag_emu/device.py
@@ -227,15 +227,10 @@ class Device(object):
         elif action['type'] == ActionType.BUTTON:
             self._simulate_action_xy(action, packets, report_count)
 
-        def send_packets() -> None:
-            nonlocal packets
-            s = sched.scheduler(time.time, time.sleep)
-            next_time = 0.0
-            for packet in packets:
-                s.enter(next_time, 1, self.send_hid_action,
-                        kwargs={'action': packet})
-                next_time += 1 / self.report_rate
-            s.run()
-
-        sim_thread = threading.Thread(target=send_packets)
-        sim_thread.start()
+        s = sched.scheduler(time.time, time.sleep)
+        next_time = 0.0
+        for packet in packets:
+            s.enter(next_time, 1, self.send_hid_action,
+                    kwargs={'action': packet})
+            next_time += 1 / self.report_rate
+        s.run()


### PR DESCRIPTION
Right now, if an error is thrown while we are sending the events, the
thread that is listeing is  not be properly handled. This causes the
device to be destroyed with the listening thread still active, resulting
in the error below.

This patch makes sure the listening thread is properly stoped and that
the file descriptors are closed before exiting.

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/anubis/git/ratbag-emu/tests/__init__.py", line 77, in collect_events
    evs += list(device.events())
  File "/usr/lib/python3.8/site-packages/libevdev/device.py", line 523, in events
    ev = self._libevdev.next_event(flags)
  File "/usr/lib/python3.8/site-packages/libevdev/_clib.py", line 872, in next_event
    raise OSError(-rc, os.strerror(-rc))
OSError: [Errno 19] No such device
```

Signed-off-by: Filipe Laíns <lains@archlinux.org>