### PR TITLE
evdev rewrite

### DIFF
--- a/ratbag_emu/device.py
+++ b/ratbag_emu/device.py
@@ -109,6 +109,14 @@ class Device(object):
 
         self._actuators = val
 
+    @property
+    def event_nodes(self) -> List[str]:
+        return [node for endpoint in self.endpoints for node in endpoint.device_nodes]
+
+    @property
+    def hidraw_nodes(self) -> List[str]:
+        return [node for endpoint in self.endpoints for node in endpoint.hidraw_nodes]
+
     def destroy(self) -> None:
         for endpoint in self.endpoints:
             endpoint.destroy()

--- a/ratbag_emu/device.py
+++ b/ratbag_emu/device.py
@@ -263,6 +263,7 @@ class Device(object):
             for evdev_device in self.event_nodes:
                 self._event_buffer.extend(list(evdev_device.events()))
             self._event_thread_lock.release()
+            time.sleep(0.001)
 
     def pop_evdev_events(self):
         self._event_thread_lock.acquire()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,19 +59,19 @@ class TestBase(object):
 
         return events
 
-    def catch_events(self, device, events, callback, wait=1):
-        devices = []
+    def catch_evdev_events(self, device, events, callback, wait=1):
+        evdev_devices = []
         for node in events:
             fd = open(node, 'rb')
             fcntl.fcntl(fd, fcntl.F_SETFL, os.O_NONBLOCK)
-            devices.append(libevdev.Device(fd))
+            evdev_devices.append(libevdev.Device(fd))
 
         evs = []
         def collect_events(stop):  # noqa: 306
             nonlocal evs
             while not stop.is_set():
-                for device in devices:
-                    evs += list(device.events())
+                for evdev_device in evdev_devices:
+                    evs += list(evdev_device.events())
 
         stop_event_thread = threading.Event()
         event_thread = threading.Thread(target=collect_events,
@@ -84,8 +84,8 @@ class TestBase(object):
         stop_event_thread.set()
         event_thread.join()
 
-        for device in devices:
-            device.fd.close()
+        for evdev_device in evdev_devices:
+            evdev_device.fd.close()
 
         received = EventData()
         for e in evs:
@@ -101,4 +101,4 @@ class TestBase(object):
             nonlocal action
             device.simulate_action(action)
 
-        return self.catch_events(device, events, callback, wait=action['duration']/1000 + 0.5)
+        return self.catch_evdev_events(device, events, callback, wait=action['duration']/1000 + 0.5)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -78,7 +78,7 @@ class TestDevice(TestDeviceBase):
                 SensorActuator(dpi=1000)
             ]
 
-    def test_mouse_report(self, device, libevdev_event_nodes):
+    def test_mouse_report(self, device):
         '''
         Test single HID report
         '''
@@ -86,16 +86,14 @@ class TestDevice(TestDeviceBase):
 
         expected = EventData(x, y)
 
-        def callback(device):
-            nonlocal expected
-            device.send_hid_action(expected)
+        device.send_hid_action(expected)
 
-        received = self.catch_evdev_events(device, libevdev_event_nodes, callback)
+        received = self.catch_evdev_events(device)
 
         assert expected.x <= received.x <= expected.x
         assert expected.y <= received.y <= expected.y
 
-    def test_movement(self, device, libevdev_event_nodes):
+    def test_movement(self, device):
         '''
         Test normal mouse movement
         '''
@@ -114,14 +112,14 @@ class TestDevice(TestDeviceBase):
             }
         }
 
-        received = self.simulate(device, libevdev_event_nodes, action)
+        received = self.simulate(device, action)
 
         expected = EventData.from_action(dpi, action)
 
         assert received.x == expected.x
         assert received.y == expected.y
 
-    def test_movement_max(self, device, libevdev_event_nodes):
+    def test_movement_max(self, device):
         '''
         Make sure we raise an error when we try to move more than possible
         '''
@@ -140,7 +138,7 @@ class TestDevice(TestDeviceBase):
         }
 
         with pytest.raises(AssertionError):
-            self.simulate(device, libevdev_event_nodes, action)
+            self.simulate(device, action)
 
     def test_duplicated_id(self):
         random.seed(0)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -78,7 +78,7 @@ class TestDevice(TestDeviceBase):
                 SensorActuator(dpi=1000)
             ]
 
-    def test_mouse_report(self, device, events):
+    def test_mouse_report(self, device, libevdev_event_nodes):
         '''
         Test single HID report
         '''
@@ -90,12 +90,12 @@ class TestDevice(TestDeviceBase):
             nonlocal expected
             device.send_hid_action(expected)
 
-        received = self.catch_evdev_events(device, events, callback)
+        received = self.catch_evdev_events(device, libevdev_event_nodes, callback)
 
         assert expected.x <= received.x <= expected.x
         assert expected.y <= received.y <= expected.y
 
-    def test_movement(self, device, events):
+    def test_movement(self, device, libevdev_event_nodes):
         '''
         Test normal mouse movement
         '''
@@ -114,14 +114,14 @@ class TestDevice(TestDeviceBase):
             }
         }
 
-        received = self.simulate(device, events, action)
+        received = self.simulate(device, libevdev_event_nodes, action)
 
         expected = EventData.from_action(dpi, action)
 
         assert received.x == expected.x
         assert received.y == expected.y
 
-    def test_movement_max(self, device, events):
+    def test_movement_max(self, device, libevdev_event_nodes):
         '''
         Make sure we raise an error when we try to move more than possible
         '''
@@ -140,7 +140,7 @@ class TestDevice(TestDeviceBase):
         }
 
         with pytest.raises(AssertionError):
-            self.simulate(device, events, action)
+            self.simulate(device, libevdev_event_nodes, action)
 
     def test_duplicated_id(self):
         random.seed(0)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -90,7 +90,7 @@ class TestDevice(TestDeviceBase):
             nonlocal expected
             device.send_hid_action(expected)
 
-        received = self.catch_events(device, events, callback)
+        received = self.catch_evdev_events(device, events, callback)
 
         assert expected.x <= received.x <= expected.x
         assert expected.y <= received.y <= expected.y


### PR DESCRIPTION
This should replace #39 and #40:

First 3 commits are from these PR.
Then we take the code from the tests in `hid-tools` in `Endpoint` to have a nice looking storing of the evdev nodes, and finally we handle the thread in `Device`, because why would we need more than one per device*


\* however, we might revisit that when we need to have more than one evdev node, one per application