### PR TITLE
github: run strict typing checks

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Static analysis with mypy
       run: |
         pip install mypy
-        mypy --ignore-missing-imports --disallow-untyped-defs -p ratbag_emu
+        mypy --ignore-missing-imports --strict -p ratbag_emu
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/ratbag_emu/device.py
+++ b/ratbag_emu/device.py
@@ -166,7 +166,7 @@ class Device(object):
         for packet in packets:
             setattr(packet, 'b{}'.format(action['data']['id']), 1)
 
-    def simulate_action(self, action: Dict[str, Any], type: int = None) -> None:
+    def simulate_action(self, action: Dict[str, Any]) -> None:
         '''
         Simulates action
 

--- a/ratbag_emu/endpoint.py
+++ b/ratbag_emu/endpoint.py
@@ -7,13 +7,13 @@ import typing
 
 import hidtools.uhid
 
-from typing import List
+from typing import List, Optional
 
 if typing.TYPE_CHECKING:
     from ratbag_emu.device import Device  # pragma: no cover
 
 
-class Endpoint(hidtools.uhid.UHIDDevice):
+class Endpoint(hidtools.uhid.UHIDDevice):  # type: ignore
     '''
     Represents a device endpoint
 
@@ -85,7 +85,7 @@ class Endpoint(hidtools.uhid.UHIDDevice):
 
         self.call_input_event(data)
 
-    def create_report(self, action: object, global_data: int = None, skip_empty: bool = True) -> List[int]:
+    def create_report(self, action: object, global_data: Optional[int] = None, skip_empty: bool = True) -> List[int]:
         '''
         Converts action into HID report
 
@@ -105,4 +105,4 @@ class Endpoint(hidtools.uhid.UHIDDevice):
         if empty and skip_empty:
             return []
 
-        return super().create_report(action, global_data)
+        return super().create_report(action, global_data)  # type: ignore


### PR DESCRIPTION
By default the static checks are very premissive. They will implicitely
define types and straight out ignore some error (like a non-optional
variable having a None value).

This patch makes the CI run strict static tests.

Signed-off-by: Filipe Laíns <lains@archlinux.org>