### PR TITLE
Introduce `HIDProperty`

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -77,7 +77,7 @@ API User->>Device: simulate_action(action)
 
 Device->>+Device: hid_action = transform_action(action)
 loop actuators
-	Device-->>Actuator: transform(data)
+    Device-->>Actuator: transform(data)
 end
 Device-->>-Device: return
 
@@ -92,4 +92,73 @@ loop packets
 end
 
 Device-->>API User: return
+```
+
+### Example state diagram
+```mermaid
+stateDiagram
+
+[*] --> Device : action
+
+state Device {
+    state fork_state <<fork>>
+
+    transform : transform
+    transform : dpi = 500
+    transform : btn5 = KEY_LEFTSHIFT + KEY_B
+
+    [*] --> transform : event
+
+    transform --> fork_state : event
+
+    fork_state --> Endpoint1
+    fork_state --> Endpoint2
+    fork_state --> Endpoint3
+
+    state Endpoint1 {
+        populate : populate
+        populate : X logical_min = 0
+        populate : X logical_max = 64
+        populate : Y logical_min = 0
+        populate : Y logical_max = 64
+        populate : buttons[0 .. 16]
+
+        device --> report_rate
+        report_rate --> populate
+
+        rdesc --> populate
+
+        [*] --> populate : event
+        populate --> [*] : array of timed packets (HID data -- bytes)
+    }
+
+    state Endpoint2 {
+        populate : populate
+        populate : X logical_min = 65
+        populate : X logical_max = 1024
+        populate : Y logical_min = 65
+        populate : Y logical_max = 1024
+
+        device --> report_rate
+        report_rate --> populate
+
+        rdesc --> populate
+
+        [*] --> populate : event
+        populate --> [*] : array of timed packets (HID data -- bytes)
+    }
+
+    state Endpoint3 {
+        populate : populate
+        populate : keyboard
+
+        device --> report_rate
+        report_rate --> populate
+
+        rdesc --> populate
+
+        [*] --> populate : event
+        populate --> [*] : array of timed packets (HID data -- bytes)
+    }
+}
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,14 +22,17 @@ class UHIDDevice
 Endpoint --|> UHIDDevice : inherited
 class Endpoint {
     -_owner Device
+    -_hid_properties List[HIDProperty]
     +rdesc List[int]
     +name str
     +number int
     +uhid_dev_is_ready bool
 
+    -_update_hid_properties() %% Parses the report descriptor and populates _hid_properties ()
     -_receive(data, size, rtype) %% HID data receive callback (triggers the firmware callback)
     +send(data) %% Sends HID data ()
     +create_report(action, skip_empty) %% Creates a report based on the HID data ()
+    +populate_hid_data(action, packets) %% Uses the _hid_properties to populate HID events ()
 }
 Endpoint --> Device : owned
 
@@ -50,3 +53,11 @@ Actuator --o Device : used (actuators)
 
 class HWComponent
 HWComponent --o Device : used (hw)
+
+class HIDProperty {
+    -keys List[str]
+
+    +populate(action) %% Transform a high-level action ()
+}
+HIDProperty --o Endpoint : used (_hid_properties)
+```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,3 +1,4 @@
+# Architecture overview (class diagram)
 ```mermaid
 classDiagram
 
@@ -60,4 +61,35 @@ class HIDProperty {
     +populate(action) %% Transform a high-level action ()
 }
 HIDProperty --o Endpoint : used (_hid_properties)
+```
+
+# `simulate_action()`
+```mermaid
+sequenceDiagram
+
+participant API User
+participant Device
+participant Actuator
+participant Endpoint
+participant HIDProperty
+
+API User->>Device: simulate_action(action)
+
+Device->>+Device: hid_action = transform_action(action)
+loop actuators
+	Device-->>Actuator: transform(data)
+end
+Device-->>-Device: return
+
+Device->>+Endpoint: populate_hid_data(hid_action, packets)
+loop HID properties
+    Endpoint-->>HIDProperty: populate(hid_action, packets)
+end
+Endpoint-->>-Device: return
+
+loop packets
+    Device->>Endpoint: send(create_report(packet))
+end
+
+Device-->>API User: return
 ```

--- a/ratbag_emu/endpoint.py
+++ b/ratbag_emu/endpoint.py
@@ -12,10 +12,10 @@ from typing import Any, List, Dict, Optional
 from ratbag_emu.hid_properties.axis import AxisProperty
 from ratbag_emu.util import EventData
 
-if typing.TYPE_CHECKING:
-    from ratbag_emu.actuator import Actuator  # pragma: no cover # noqa: F401
-    from ratbag_emu.device import Device  # pragma: no cover
-    from ratbag_emu.hid_property import HIDProperty  # pragma: no cover
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from ratbag_emu.actuator import Actuator  # noqa: F401
+    from ratbag_emu.device import Device
+    from ratbag_emu.hid_property import HIDProperty
 
 
 class Endpoint(hidtools.uhid.UHIDDevice):  # type: ignore

--- a/ratbag_emu/firmware.py
+++ b/ratbag_emu/firmware.py
@@ -5,8 +5,8 @@ import typing
 
 from typing import List
 
-if typing.TYPE_CHECKING:
-    from ratbag_emu.device import Device  # pragma: no cover
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from ratbag_emu.device import Device
 
 
 class Firmware(object):

--- a/ratbag_emu/hid_properties/axis.py
+++ b/ratbag_emu/hid_properties/axis.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+
+import logging
+import typing
+
+from typing import Any, Dict, List
+
+from ratbag_emu.hid_property import HIDProperty
+from ratbag_emu.util import EventData
+
+if typing.TYPE_CHECKING:
+    from ratbag_emu.actuator import Actuator  # pragma: no cover # noqa: F401
+    from ratbag_emu.endpoint import Endpoint  # pragma: no cover
+
+
+class AxisProperty(HIDProperty):
+    '''
+    Represents an HID axis
+
+    Transform x and y high-level actions to HID data
+    '''
+    def __init__(self, owner: 'Endpoint', key: str, min: int, max: int):
+        super().__init__(owner, key)
+        self.__logger = logging.getLogger('ratbag-emu.hid_property.axis')
+
+        self._min = min
+        self._max = max
+
+        self.__logger.debug(f'{self._owner.name}: registered HID axis \'{key}\' (min={min}, max={max})')
+
+    def populate(self, action: Dict[str, Any], packets: List[EventData]) -> None:
+        report_count = len(packets)
+        dot_buffer = real_dot_buffer = action[self.key]
+        '''
+        Initialize dot_buffer, real_dot_buffer and step for X and Y
+
+        dot_buffer holds the ammount of dots left to send (kind of,
+        read below).
+
+        We actually have two variables for this, real_dot_buffer and
+        dot_buffer. dot_buffer mimics the user movement and
+        real_dot_buffer holds true number of dots left to send.
+        When using high report rates (ex. 1000Hz) we usually don't
+        have a full dot to send, that's why we need two variables. We
+        subtract the step to dot_buffer at each iteration, when the
+        difference between dot_buffer and real_dot_buffer is equal
+        or higher than 1 dot we then send a HID report to the device
+        with that difference (int! we send the int part of the
+        difference) and update real_dot_buffer to include this
+        changes.
+        '''
+
+        assert dot_buffer <= self._max * report_count
+        step = dot_buffer / report_count
+
+        for packet in packets:
+            if not real_dot_buffer:
+                break
+
+            dot_buffer -= step
+            diff = int(round(real_dot_buffer - dot_buffer))
+            if abs(diff) >= 1:
+                if abs(diff) > self._max:
+                    diff = self._max if diff > 0 else self._min
+                setattr(packet, self._key, diff)
+                real_dot_buffer -= diff

--- a/ratbag_emu/hid_properties/axis.py
+++ b/ratbag_emu/hid_properties/axis.py
@@ -8,9 +8,9 @@ from typing import Any, Dict, List
 from ratbag_emu.hid_property import HIDProperty
 from ratbag_emu.util import EventData
 
-if typing.TYPE_CHECKING:
-    from ratbag_emu.actuator import Actuator  # pragma: no cover # noqa: F401
-    from ratbag_emu.endpoint import Endpoint  # pragma: no cover
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from ratbag_emu.actuator import Actuator  # noqa: F401
+    from ratbag_emu.endpoint import Endpoint
 
 
 class AxisProperty(HIDProperty):

--- a/ratbag_emu/hid_property.py
+++ b/ratbag_emu/hid_property.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+
+import logging
+import typing
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+from ratbag_emu.util import EventData
+
+if typing.TYPE_CHECKING:
+    from ratbag_emu.endpoint import Endpoint  # pragma: no cover
+
+
+class HIDProperty(ABC):
+    '''
+    Transforms high-level actions to HID data
+    '''
+    def __init__(self, owner: 'Endpoint', key: str) -> None:
+        self.__logger = logging.getLogger('ratbag-emu.hid_property')
+
+        self._owner = owner
+        self._key = key
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    @abstractmethod
+    def populate(self, action: Dict[str, Any], packets: List[EventData]) -> None:
+        '''
+        Populates action
+        '''

--- a/ratbag_emu/hid_property.py
+++ b/ratbag_emu/hid_property.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List
 
 from ratbag_emu.util import EventData
 
-if typing.TYPE_CHECKING:
-    from ratbag_emu.endpoint import Endpoint  # pragma: no cover
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from ratbag_emu.endpoint import Endpoint
 
 
 class HIDProperty(ABC):

--- a/ratbag_emu/util.py
+++ b/ratbag_emu/util.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 
-from enum import Enum
 from typing import Any, Dict, Union
 
 
@@ -26,11 +25,5 @@ class EventData(object):
 
     @staticmethod
     def from_action(dpi: int, action: Dict[str, Any]) -> 'EventData':
-        assert action['type'] == ActionType.XY
         return EventData(x=int(round(mm2inch(action['data']['x']) * dpi)),
                          y=int(round(mm2inch(action['data']['y']) * dpi)))
-
-
-class ActionType(Enum):
-    XY = 1
-    BUTTON = 2

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -7,7 +7,7 @@ import pytest
 
 from ratbag_emu import Device
 from ratbag_emu.actuators import SensorActuator
-from ratbag_emu.util import ActionType, EventData
+from ratbag_emu.util import EventData
 
 from tests.base import TestBase
 
@@ -101,7 +101,6 @@ class TestDevice(TestDeviceBase):
         ]
 
         action = {
-            'type': ActionType.XY,
             'duration': 500,
             'data': {
                 'x': 5,
@@ -127,7 +126,6 @@ class TestDevice(TestDeviceBase):
         ]
 
         action = {
-            'type': ActionType.XY,
             'duration': 1,
             'data': {
                 'x': 5,


### PR DESCRIPTION
Replaces #45

This deals with the issues from #45 in a nicer way. Instead of a HID Actuator, like suggested, we introduce `HIDProperty`. Each endpoint has a list of properties which is populated by parsing the report descriptor.

`HIDProperty` has a `populate` method which receives an action after it has been updated by the device actuators, and populates a list of HID events with the according HID data. This replaces the `Device._simulate_action_*`.

The idea is to subclass `HIDProperty` for each supported HID data type (eg. `AxisProperty`).

This allows us to drop `ActionType` as everything is now dynamically resolved to HID properties.

What do you think @bentiss? Does this resolve your concerns?